### PR TITLE
chore: audit codebase and fix minor bugs

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,4 +1,4 @@
-syntax = "Lua52"
+syntax = "Lua51"
 column_width = 120
 indent_type = "Spaces"
 indent_width = 4

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,5 +1,5 @@
-<!-- TODO: replace with release banner image -->
-<img width="1923" height="817" alt="Panels+ v1.3.0 banner" src="PLACEHOLDER_BANNER_IMAGE_URL" />
+
+<img width="1923" height="817" alt="Panels+ v1.3.0 banner" src="https://raw.githubusercontent.com/KristanLaimon/PanelsPlus/main/.github/panels+_logo.png" />
 
 # Panels+ | The Touchy Update 
 
@@ -99,7 +99,7 @@ I couldn't fit every single suggestion in — that would've taken forever, and I
 
 ## A note on OCR word lookup
 
-- **OCR isn't installed by default.** Word lookup on comics/manga relies on KOReader's own OCR engine, which you need to set up manually first — see the [KOReader OCR setup guide](PLACEHOLDER_OCR_SETUP_LINK) <!-- TODO: confirm/replace with the exact KOReader OCR install docs link -->.
+- **OCR isn't installed by default.** Word lookup on comics/manga relies on KOReader's own OCR engine, which you need to set up manually first — see the [KOReader OCR setup guide](https://koreader.rocks/user_guide/#L2-ocr) .
 - **It's genuinely experimental, and can be flaky.** Reliably finding word boundaries in hand-lettered, stylized comic/manga text turned out to be a much harder problem than I expected — call it a skill issue on my part. Expect the occasional wrong word or missed tap.
 - **Workaround:** while this stabilizes, I'd recommend binding a comfortable multiswipe gesture to "Open dictionary lookup" as a fallback — it's a lot more reliable than the touch-and-hold OCR path for now.
 


### PR DESCRIPTION
Audited codebase and fixed:
- Reverted stylua configuration to use `Lua51` syntax instead of `Lua52` in `.stylua.toml`.
- Replaced missing markdown image URL placeholders with the correct `panels+_logo.png` link.
- Replaced missing markdown OCR setup link placeholders with the KOReader guide link.

---
*PR created automatically by Jules for task [12482373000285929892](https://jules.google.com/task/12482373000285929892) started by @KristanLaimon*